### PR TITLE
make urls tappable

### DIFF
--- a/lib/detail.dart
+++ b/lib/detail.dart
@@ -4,6 +4,9 @@ import 'package:audioplayer/audioplayer.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:itsallwidgets_podcast/data/rss_response.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:verbal_expressions/verbal_expressions.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
 
 enum PlayerState { stopped, playing, paused }
 
@@ -151,7 +154,11 @@ class PodCastDetailState extends State<PodCastDetail> {
                   widget.item.description,
                   style: TextStyle(fontSize: 16.0),
                 ),
-              )
+              ),
+              Padding(
+                padding: EdgeInsets.all(2.0),
+                child: displayUrls(widget.item.description),
+              ),
             ],
           ),
         ),
@@ -234,4 +241,43 @@ class PodCastDetailState extends State<PodCastDetail> {
           ],
         ),
       );
+
+  Widget displayUrls(String description) {
+    var regex = VerbalExpression()
+      ..startOfLine()
+      ..then("https")
+      ..then("://")
+      ..anythingBut(" ")
+      ..endOfLine();
+
+    // Create an example URL
+    String url = description;
+
+    // Use VerbalExpression's hasMatch() method to test if the entire string matches the regex
+    regex.hasMatch(url); //True
+
+    regex.toString();
+
+    final urlRegex = RegExp('https\:\/\/(?:[^\#,]*)', multiLine: true);
+    var urlToDisplay =
+        (urlRegex.allMatches(description).map((m) => m.group(0)));
+
+    for (var n in urlToDisplay) {
+      return Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Linkify(
+              onOpen: (url) async {
+                if (await canLaunch(url)) {
+                  await launch(url);
+                } else {
+                  throw 'Could not launch $url';
+                }
+              },
+              text: '\n${urlToDisplay}\n',
+              style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16.0,
+                  color: Colors.blue)));
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
   rxdart:
+  verbal_expressions: ^0.4.0
+  flutter_linkify: 1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR makes the `urls` returning from rss feed into tappable links so that users can open them on device's web browser.
Although I couldn't do much with the repeatable url data that is displayed, since it is coming from rss feed, however, atleast the urls are tappable now.

![screen shot 2019-01-23 at 9 03 09 pm](https://user-images.githubusercontent.com/16548367/51617491-5ed04e80-1f52-11e9-8863-44beacdd49c7.png)
![screen shot 2019-01-23 at 9 03 21 pm](https://user-images.githubusercontent.com/16548367/51617494-60017b80-1f52-11e9-92f6-d2db7022446a.png)

Any feedback / suggestions are welcome.
